### PR TITLE
PMUI-1: Fixed the issues to match with gravity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greenville/mui-theme",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A Material UI theme implementing Pearson UX specs",
   "author": "Pearson-Higher-Ed",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -442,7 +442,7 @@ const pearsonMuiTheme = {
       },
       outlined: {
         padding: '7px 17px',
-        boxShadow: '0 5px 22px 4px rgba(0, 0, 0, 0.03), 0 7px 8px -4px rgba(0, 0, 0, 0.05)',
+        boxShadow: 'none',
         borderColor: colors.mediumGray,
         color: colors.mediumGray,
         backgroundColor: 'transparent',
@@ -527,6 +527,7 @@ const pearsonMuiTheme = {
       sizeSmall: {
         padding: '5px 24px',
         fontSize: '0.875rem',
+        lineHeight: '20px',
         '& span': {
           minWidth: 80
         }
@@ -787,6 +788,11 @@ const pearsonMuiTheme = {
       current: {
         backgroundColor: colors.moonlight,
         color: colors.charcoal
+      }
+    },
+    MuiPickersCalendar: {
+      transitionContainer: {
+        minHeight: 236
       }
     }
   }


### PR DESCRIPTION
Fixed the issues for the below tickets.
1. PMUI-1 - Removed the box-shadow for outlined button
2. PMUI-3 - Added line-height of 20 px so that the overall small size button height is matched with gravity spec of 32px.
3. Added MuiPickersCalendar for Redding calendar issue fix.